### PR TITLE
Add necessary functions for the ground-crossing service

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,9 @@ pub use transform::{Transform, TransformError};
 
 pub use crate::proj::Area;
 pub use crate::proj::Coord;
+pub use crate::proj::Coord3D;
 pub use crate::proj::Info;
+pub use crate::proj::Point;
 pub use crate::proj::Proj;
 pub use crate::proj::ProjBuilder;
 pub use crate::proj::ProjCreateError;


### PR DESCRIPTION
Problem: in the https://github.com/aerodome-usa/drone-ground-crossing/ repository we need conversions using vertical datums, and this crate does only support 2D coordinate conversions. Adding 3D conversions should be trivial.

Solution: add a function for 3D conversions, use `convert` (for 2D conversions) as example.

Note that this branch (and the target `drone-ground-crossing` branch) checkout not from `main`, but from a 3-months ago commit which used PROJ 9.4.0. This is necessary as Nix does not package PROJ 9.6.0 yet. We could ignore that, which would require building from sources and providing sqlite library to `buildInputs` downstream; I assumed we do not want that.